### PR TITLE
Fix for running on arm64

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ int main(int argc, char** argv) {
 
     std::string out_directory = ".";
 
-    char argument;
+    signed char argument;
     while ((argument = getopt_long(argc, argv, "o:h", options, nullptr)) != -1) {
         switch (argument) {
             case 'o':


### PR DESCRIPTION
Hi,

currently rampler fails to run on arm64 - leading to arm64 regression for the same in its Debian package.
```
rampler split <in>.fasta 500000
```
This is so because the char not being signed interprets -1 as 255 on arm64 architecture.
For more details: The failing test can be found [here](https://ci.debian.net/data/autopkgtest/testing/arm64/r/rampler/6794192/log.gz)
And the corresponding script that fails can be found [here](https://sources.debian.org/src/rampler/1.1.1-2/debian/tests/run-unit-test/)